### PR TITLE
API: Make StartAge constant

### DIFF
--- a/apps/Data_io.cpp
+++ b/apps/Data_io.cpp
@@ -2834,6 +2834,8 @@ int findRunPeriod( GDALRasterImage *refGrid, MYDate &minMY, MYDate &maxMY )
     minCy2 = MINSEED; 
     maxCy2 = MAXSEED; 
     spatial = ( refGrid != NULL ); 
+
+    StartAge = 1;
     
     // Point mode case.  If we are running in point mode yearPlanted, StartAge and 
     // EndAge are already defined. 


### PR DESCRIPTION
Closes #21. Hardcodes StartAge = 1 and removes support for it as a parameter.