### PR TITLE
BUG: Make yrPreStart condition only check EndYear

### DIFF
--- a/apps/The_3PG_Model.cpp
+++ b/apps/The_3PG_Model.cpp
@@ -796,9 +796,9 @@ skipPreYearCalcs:
                 yrPreStart = true;
             if ((calYear == yearPlanted) && (calMonth < StartMonth))
                 yrPreStart = true;
-            if (calYear > (yearPlanted + EndYear))
+            if (calYear > (EndYear))
                 yrPstEnd = true;
-            if ((calYear == (yearPlanted + EndYear)) && (calMonth > StartMonth))
+            if ((calYear == (EndYear)) && (calMonth > StartMonth))
                 yrPstEnd = true;
 
 


### PR DESCRIPTION
This PR resolves incorrect values found in TIFs produced at the end of the model run. Errors caused by incorrect condition when checking whether to skip monthly calculations or to continue computing.