### PR TITLE
BUG: Reconcile calculations with 2005 updates

### DIFF
--- a/apps/The_3PG_Model.cpp
+++ b/apps/The_3PG_Model.cpp
@@ -142,6 +142,14 @@ double CanopyTranspiration(double Q, double VPD, double h,
     return CT;
 }
 
+double getGammaFoliage(InputParams& params, double& StandAge) {
+    double gf;
+    gf = params.gammaFx* params.gammaF0 /
+        (params.gammaF0 + (params.gammaFx - params.gammaF0) *
+            exp(-12 * log(1 + params.gammaFx / params.gammaF0) * StandAge / params.tgammaF));
+    return gf;
+}
+
 //-----------------------------------------------------------------------------
 
 //Standage function translated from March beta of Excel 3-PG
@@ -444,9 +452,7 @@ void runTreeModel(std::unordered_map<std::string, PPPG_OP_VAR> opVars, MYDate sp
 
     vars.fracBB = params.fracBB1 + (params.fracBB0 - params.fracBB1) * exp(-ln2 * (StandAge / params.tBB)); //Modified StandAge
     Density = params.rhoMax + (params.rhoMin - params.rhoMax) * exp(-ln2 * (StandAge / params.tRho));
-    gammaF = params.gammaFx * params.gammaF0 /
-        (params.gammaF0 + (params.gammaFx - params.gammaF0) *
-            exp(-12 * log(1 + params.gammaFx / params.gammaF0) * StandAge / params.tgammaF));
+    gammaF = getGammaFoliage(params, StandAge);
 
     vars.StandVol = vars.WS * (1 - vars.fracBB) / Density;
     oldVol = vars.StandVol;
@@ -825,9 +831,7 @@ void runTreeModel(std::unordered_map<std::string, PPPG_OP_VAR> opVars, MYDate sp
                 SLA = params.SLA1 + (params.SLA0 - params.SLA1) * exp(-ln2 * pow((StandAge / params.tSLA), 2));  //Modified StandAge
                 vars.fracBB = params.fracBB1 + (params.fracBB0 - params.fracBB1) * exp(-ln2 * (StandAge / params.tBB));  //Modified StandAge
                 Density = params.rhoMax + (params.rhoMin - params.rhoMax) * exp(-ln2 * (StandAge / params.tRho));
-                gammaF = params.gammaFx * params.gammaF0 /
-                    (params.gammaF0 + (params.gammaFx - params.gammaF0) *
-                        exp(-12 * log(1 + params.gammaFx / params.gammaF0) * StandAge / params.tgammaF));
+                gammaF = getGammaFoliage(params, StandAge);
 
                 //update stsand characteristics
                 vars.LAI = vars.WF * SLA * 0.1;


### PR DESCRIPTION
This PR _finally_ resolves the long standing issue of value differences between V2 (ours) and 2005 V3 models. 

## Changes

- Update calculation order to match Excel V3 execution
  - Canopy conductance, canopy transpiration, and water balance calculations moved from after to before end-of-month biomass calculations. Gamma foliage moved from before end-of-month to after and in run initialization.
- Update light interception to account for partial canopy light interception 
https://github.com/IRSS-UBC/3pg2/blob/b2a6eb7365f2608a2765c874d84f393544e770cb/apps/The_3PG_Model.cpp#L688
- Modify soil water balance model to include updated NPP, Transp, and ASW interactions and pooled soil water
https://github.com/IRSS-UBC/3pg2/blob/b2a6eb7365f2608a2765c874d84f393544e770cb/apps/The_3PG_Model.cpp#L752-L765
- Update canopy conductance and canopy transpiration calculations
https://github.com/IRSS-UBC/3pg2/blob/b2a6eb7365f2608a2765c874d84f393544e770cb/apps/The_3PG_Model.cpp#L730-L739
https://github.com/IRSS-UBC/3pg2/blob/b2a6eb7365f2608a2765c874d84f393544e770cb/apps/The_3PG_Model.cpp#L138-L139

## Remaining Work

These changes match the 3PG Version 3 monthly values, **except** for the final output. Tested WS, WF, WR, Stemno, and DBH outputs. The incorrect final outputs will be addressed in #63.