### PR TITLE
ENH: Added support for Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 _deps
+cmake-build-debug
 
 # Builds/Outs
 out/*

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ build/*
 # Vscode 
 .vscode/*
 .vs/*
+
+# JetBrains
+.idea

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,18 @@
 # CMakeList.txt : Top-level CMake project file, do global configuration
 # and include sub-projects here.
 cmake_minimum_required (VERSION 3.8)
-set (CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 20)
 
 # Enable use of _ROOT variables
 if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)
 endif()
 
-project ("3pg")
+project("3pg")
 
 # Include sub-projects.
 include_directories("include")
-add_subdirectory ("apps")
+add_subdirectory("apps")
 
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
     add_subdirectory("tests")

--- a/README.md
+++ b/README.md
@@ -4,9 +4,20 @@
 If you notice a bug, or have an idea for a feature request, please use GitHub issues.
 
 # Running 3-PG
-Download and unzip the latest release from GitHub. Then, run using the run.bat script in the release folder. 
+Download and unzip the latest release from GitHub. Then, run using the run.bat script in the release folder. In Linux, you need to source the run.sh script to allow to temporarily export PROJ, if available. 
 
 Alternatively, you may run the executable directly. If you do this, ensure that the PROJ_DATA environment variable has been set to the 'proj' folder. Runtime warnings indicating 'proj.db' not found will occur if this is not done. This is necessary because 'proj' is a dependency of GDAL, which this new version of 3-PG utilizing .tif images relies on.
+
+To compile 3-PG from source in release mode, first check the prerequisistes, then run:
+```
+# Windows
+cmake -D CMAKE_BUILD_TYPE=Release -B build
+cmake --build build
+
+# Ubuntu
+cmake -G "Unix Makefiles" -D CMAKE_BUILD_TYPE=Release -B build
+cmake --build build
+```
 
 # Developing 3-PG
 ### Prerequisistes
@@ -15,7 +26,7 @@ Alternatively, you may run the executable directly. If you do this, ensure that 
 * [CMake](https://cmake.org/download/) (3.15 or higher)
 * [Git](https://git-scm.com/download/win)
 
-**On Ubuntu**:
+**On Linux**:
 * [g++](https://gcc.gnu.org/) (14 or higher)
 * [CMake](https://cmake.org/download/) (3.15 or higher)
 * [Git](https://git-scm.com/downloads/linux)
@@ -68,18 +79,13 @@ And you can make it the default compiler
 sudo update-alternatives --install /usr/bin/g++ g++ /usr/local/gcc-14.2.0/bin/g++-14.2.0 14
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/local/gcc-14.2.0/bin/gcc-14.2.0 14
 ```
-- to install gdal you can use apt
-- note that in Linux, we link gdal dynamically
+- install gdal and boost via apt (note that in Linux we link gdal dynamically)
 ```
-sudo apt install gdal-bin libgdal-dev
+sudo apt install gdal-bin libgdal-dev libboost-all-dev
 ```
 - make sure that gdal is available in the system PATH
 ```
 export PATH="$PATH:<path_to_gdal_bin_dir>"
-```
-- similar for boost
-```
-sudo apt install libboost-all-dev
 ```
 
 ### Building project
@@ -97,18 +103,6 @@ unit tests. Running ./make_build.sh will build only the project in Release mode.
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 sudo apt-get update
 sudo apt-get install --only-upgrade libstdc++6
-```
-
-# Using 3-PG
-If you are simply interested in using 3-PG, you can compile the project with:
-```
-# Windows
-cmake -D CMAKE_BUILD_TYPE=Release -B build
-cmake --build build
-
-# Ubuntu
-cmake -G "Unix Makefiles" -D CMAKE_BUILD_TYPE=Release -B build
-cmake --build build
 ```
 
 ### Debugging the project

--- a/README.md
+++ b/README.md
@@ -3,23 +3,30 @@
 
 If you notice a bug, or have an idea for a feature request, please use GitHub issues.
 
-# running 3-PG
-download and unzip the latest release from GitHub. Then, run using the run.bat script in the release folder. 
+# Running 3-PG
+Download and unzip the latest release from GitHub. Then, run using the run.bat script in the release folder. 
 
 Alternatively, you may run the executable directly. If you do this, ensure that the PROJ_DATA environment variable has been set to the 'proj' folder. Runtime warnings indicating 'proj.db' not found will occur if this is not done. This is necessary because 'proj' is a dependency of GDAL, which this new version of 3-PG utilizing .tif images relies on.
 
-# developing 3-PG
+# Developing 3-PG
 ### Prerequisistes
+**On Windows**:
 * [Visual Studio 2022](https://visualstudio.microsoft.com/vs/) with the C++ workload installed
 * [CMake](https://cmake.org/download/) (3.15 or higher)
 * [Git](https://git-scm.com/download/win)
 
-### clone the repository
+**On Ubuntu**:
+* [g++](https://gcc.gnu.org/) (14 or higher)
+* [CMake](https://cmake.org/download/) (3.15 or higher)
+* [Git](https://git-scm.com/downloads/linux)
+
+### Clone the repository
 ```
 git clone https://github.com/IRSS-UBC/3pg.git
 ```
 
-### Installing GDAL and Boost
+### Installing dependencies
+**On Windows**:
  - instructions for installing gdal using vcpkg here: https://gdal.org/download.html#vcpkg
 ```
 git clone https://github.com/Microsoft/vcpkg.git
@@ -33,7 +40,7 @@ cd vcpkg
    - type 'env' into the Windows search bar and select 'Edit environment variables for your account'.
    - under user variables click 'new' and set VCPKG_ROOT as the variable name, and the path to the vcpkg folder as the variable value (for me this was C:\Github\vcpkg)
    - create another new user variable with variable name GDAL_DIR and set it as the path to the folder containing the GDALConfig.cmake file (within in the vcpkg\packages folder). For me this was C:\Github\vcpkg\packages\gdal_x64-windows\share\gdal.
-   - navigate the the vcpkg folder from the command line, and run the command.
+   - navigate to the vcpkg folder from the command line, and run the command.
 ```
 ./vcpkg install gtest
 ```
@@ -42,30 +49,85 @@ cd vcpkg
 ```
 - note: installing boost will take a while, for me it took 1.7 hours.
 - go to the vcpkg folder and navigate to vcpkg/installed/x64-windows/include/ (note: x64-windows may be a different folder on your installation).
-- within that folder, there should be a folder called 'boost'. Copy the whole folder and paste it into the 3pg2/include directory.
+- within that folder, there should be a folder called 'boost'. Copy the whole folder and paste it into the 3pg/include directory.
 
-### building project
+**On Linux**:
+- gcc-14 is only available on Ubuntu 24.04 and higher from official repositories, so if you're using an older distribution you can compile it from source
+```
+sudo apt install build-essential
+sudo apt install libmpfr-dev libgmp3-dev libmpc-dev -y
+wget http://ftp.gnu.org/gnu/gcc/gcc-14.2.0/gcc-14.2.0.tar.gz
+tar -xf gcc-14.2.0.tar.gz
+cd gcc-14.2.0
+./configure -v --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu --prefix=/usr/local/gcc-14.2.0 --enable-checking=release --enable-languages=c,c++ --disable-multilib --program-suffix=-14.2.0
+make
+sudo make install
+```
+And you can make it the default compiler
+```
+sudo update-alternatives --install /usr/bin/g++ g++ /usr/local/gcc-14.2.0/bin/g++-14.2.0 14
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/local/gcc-14.2.0/bin/gcc-14.2.0 14
+```
+- to install gdal you can use apt
+- note that in Linux, we link gdal dynamically
+```
+sudo apt install gdal-bin libgdal-dev
+```
+- make sure that gdal is available in the system PATH
+```
+export PATH="$PATH:<path_to_gdal_bin_dir>"
+```
+- similar for boost
+```
+sudo apt install libboost-all-dev
+```
+
+### Building project
+**On Windows**:
  - navigate to the project directory and run either ./run_tests.bat or ./make_build.bat.
 Running ./run_tests.bat will build the project with the testing folder and run the
 unit tests. Running ./make_build.bat will build only the project.
  - if you see any 'missing *.dll' errors, see the 'missing dll errors' section of this readme for how to fix.
 
-### debugging the project
- - Open 3pg.sln in the buid folder using Microsoft Visual Studio. There should be a box 'solution explorer' open. In 'solution explorer' right click on the '3pg' project and select 'set as startup project'.
+**On Linux**:
+- running ./run_tests.sh will build the project with the testing folder and run the
+unit tests. Running ./make_build.sh will build only the project in Release mode.
+- if you get an error like 'GLIBCXX_3.4.31/32 not found', you probably need to update libstdc++6
+ ```
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+sudo apt-get update
+sudo apt-get install --only-upgrade libstdc++6
+```
+
+# Using 3-PG
+If you are simply interested in using 3-PG, you can compile the project with:
+```
+# Windows
+cmake -D CMAKE_BUILD_TYPE=Release -B build
+cmake --build build
+
+# Ubuntu
+cmake -G "Unix Makefiles" -D CMAKE_BUILD_TYPE=Release -B build
+cmake --build build
+```
+
+### Debugging the project
+ - Open 3pg.sln in the build folder using Microsoft Visual Studio. There should be a box 'solution explorer' open. In 'solution explorer' right click on the '3pg' project and select 'set as startup project'.
  - Press f5 to build & debug.
  -  If you see any 'missing *.dll' errors, see the 'missing dll errors' section of this readme for how to fix.
+ - For compilations with gcc, you can debug with gdb in any IDE that supports it
 
-### missing dll errors
+### Missing dll errors
  - You may see any number of 'missing *.dll' errors. To fix these, you will need to add the windows debug bin folder from vcpkg to the 'Path' environment variable:
    - Go to the vcpkg folder, click on 'installed', then 'x64-windows', then 'debug', then 'bin'. This folder should be filled with a few .py files, and lots of .dll and .pdb files. 
    - Copy the full path (for example C:\github\vcpkg\installed\x64-windows\debug\bin).
    - type 'env' into the Windows search bar and select 'Edit environment variables for your account'.
-   - double click on 'Path'.
+   - double-click on 'Path'.
    - select 'new'.
    - paste the copied path, then click 'ok' twice.
 - note: you will have to close visual studio and re-open it again for the missing dll errors, this is because it does not automatically reload environment variables whenever they are changed.
 - after re-opening Visual Studio with the same project, try to build again.
 
-### testing
+### Testing
  - Unit testing: there are unit tests which test the correctness of the DataInput, and DataOuptut classes essential to this version of 3PG's usage. GoogleTest is used as a testing framework. The unit tests can be ran using the run_tests.bat batch file.
  - Model testing: There are python tests which test the correctness of the model, using previously verified outputs. The python tests, since they rely on relatively large images to run, are not included in this repository.

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ git clone https://github.com/IRSS-UBC/3pg.git
 ```
 git clone https://github.com/Microsoft/vcpkg.git
 cd vcpkg
-./bootstrap-vcpkg.bat for Windows # ./bootstrap-vcpkg.sh for unix-like OS's
-./vcpkg integrate install
-./vcpkg install gdal
+.\bootstrap-vcpkg.bat
+.\vcpkg integrate install
+.\vcpkg install gdal
 ```
  - note: installing gdal will take a while, for me it took 4.4 hours.
  - add GDAL_DIR and VCPKG_ROOT to the environment variables:
@@ -53,10 +53,10 @@ cd vcpkg
    - create another new user variable with variable name GDAL_DIR and set it as the path to the folder containing the GDALConfig.cmake file (within in the vcpkg\packages folder). For me this was C:\Github\vcpkg\packages\gdal_x64-windows\share\gdal.
    - navigate to the vcpkg folder from the command line, and run the command.
 ```
-./vcpkg install gtest
+.\vcpkg install gtest
 ```
 ```
-./vcpkg install boost
+.\vcpkg install boost
 ```
 - note: installing boost will take a while, for me it took 1.7 hours.
 - go to the vcpkg folder and navigate to vcpkg/installed/x64-windows/include/ (note: x64-windows may be a different folder on your installation).
@@ -83,10 +83,6 @@ sudo update-alternatives --install /usr/bin/gcc gcc /usr/local/gcc-14.2.0/bin/gc
 ```
 sudo apt install gdal-bin libgdal-dev libboost-all-dev
 ```
-- make sure that gdal is available in the system PATH
-```
-export PATH="$PATH:<path_to_gdal_bin_dir>"
-```
 
 ### Building project
 **On Windows**:
@@ -97,7 +93,7 @@ unit tests. Running ./make_build.bat will build only the project.
 
 **On Linux**:
 - running ./run_tests.sh will build the project with the testing folder and run the
-unit tests. Running ./make_build.sh will build only the project in Release mode.
+unit tests. Running ./make_build.sh will build only the project.
 - if you get an error like 'GLIBCXX_3.4.31/32 not found', you probably need to update libstdc++6
  ```
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ To compile 3-PG from source in release mode, first check the prerequisistes, the
 ```
 # Windows
 cmake -D CMAKE_BUILD_TYPE=Release -B build
-cmake --build build
+cmake --build build -j 4
 
 # Ubuntu
 cmake -G "Unix Makefiles" -D CMAKE_BUILD_TYPE=Release -B build
-cmake --build build
+cmake --build build -j 4
 ```
 
 # Developing 3-PG

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -15,15 +15,23 @@ set(SOURCE_FILES
 add_executable(${PROJECT_NAME} ${SOURCE_FILES} main.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE GDAL::GDAL)
 
-#statically link
-set(CMAKE_FIND_LIBRARY_SUFFIXES ".lib")
 if(MSVC)
+	#statically link
+	set(CMAKE_FIND_LIBRARY_SUFFIXES ".lib")
 	target_compile_options(${PROJECT_NAME} PRIVATE /MT)
 	target_link_options(${PROJECT_NAME} PRIVATE /INCREMENTAL:NO /NODEFAULTLIB:MSVCRT)
+else()
+	# link Boost and Threads
+	find_package(Boost COMPONENTS system thread REQUIRED)
+	find_package(Threads REQUIRED)
+	target_link_libraries(${PROJECT_NAME} PRIVATE Boost::system Boost::thread Threads::Threads)
 endif()
 
 # Debug mode
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
 	add_library(3pg2Test ${SOURCE_FILES})
 	target_link_libraries(3pg2Test PRIVATE GDAL::GDAL)
+	if(NOT MSVC)
+		target_link_libraries(${PROJECT_NAME} PRIVATE Boost::system Boost::thread Threads::Threads)
+	endif()
 endif()

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -5,21 +5,24 @@ set(SOURCE_FILES
 	DataInput.hpp
 	DataOutput.cpp
 	DataOutput.hpp
-	GDALRasterImage.cpp 
+	GDALRasterImage.cpp
 	GDALRasterImage.hpp
 	ParamStructs.hpp
 	3pgModel.cpp
-    	3pgModel.hpp
+    3pgModel.hpp
 )
 
-add_executable(${PROJECT_NAME} ${SOURCE_FILES} main.cpp )
+add_executable(${PROJECT_NAME} ${SOURCE_FILES} main.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE GDAL::GDAL)
 
 #statically link
 set(CMAKE_FIND_LIBRARY_SUFFIXES ".lib")
-target_compile_options(${PROJECT_NAME} PRIVATE /MT)
-target_link_options(${PROJECT_NAME} PRIVATE /INCREMENTAL:NO /NODEFAULTLIB:MSVCRT)
+if(MSVC)
+	target_compile_options(${PROJECT_NAME} PRIVATE /MT)
+	target_link_options(${PROJECT_NAME} PRIVATE /INCREMENTAL:NO /NODEFAULTLIB:MSVCRT)
+endif()
 
+# Debug mode
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
 	add_library(3pg2Test ${SOURCE_FILES})
 	target_link_libraries(3pg2Test PRIVATE GDAL::GDAL)

--- a/apps/DataInput.cpp
+++ b/apps/DataInput.cpp
@@ -869,7 +869,7 @@ bool DataInput::inputFinished(bool modelModeSpatial) {
 bool DataInput::getInputParams(long cellIndex, InputParams& params) {
 	//error checking
 	if (!finishedInput) {
-		throw std::exception("should NOT be able to call getInputParams() if input failed!");
+		throw std::runtime_error("should NOT be able to call getInputParams() if input failed!");
 	}
 
 	//declare, copy values into, then return an instance of InputParams
@@ -1005,13 +1005,13 @@ double DataInput::getValFromInputParam(std::string paramName, long cellIndex) {
 		}
 	}
 
-	throw std::exception("a parameter has been set incorrectly as neither a scalar or a grid.");
+	throw std::runtime_error("a parameter has been set incorrectly as neither a scalar or a grid.");
 }
 
 bool DataInput::getSeriesParams(long cellIndex, int year, int month, SeriesParams& params) {
 	//error checking
 	if (!finishedInput) {
-		throw std::exception("should NOT be able to call getInputParams() if input failed!");
+		throw std::runtime_error("should NOT be able to call getInputParams() if input failed!");
 	}
 
 	//if one of the calls to getValFromSeriesParams() throws an std::runtime_error
@@ -1085,7 +1085,7 @@ double DataInput::getValFromSeriesParam(int paramIndex, int year, int month, lon
 		}
 	}
 
-	throw std::exception("a parameter has been set incorrectly as neither a scalar or a grid.");
+	throw std::runtime_error("a parameter has been set incorrectly as neither a scalar or a grid.");
 }
 
 bool DataInput::getManagementParam(ManagementIndex index, long cellIndex, int year, double& val) {

--- a/apps/main.cpp
+++ b/apps/main.cpp
@@ -17,16 +17,16 @@ Use of this software assumes agreement to this condition of use
 #define _WIN32_WINNT 0x0601
 
 #include <cstdlib>
-#include <cstring>
 #include <iostream>
 #include <fstream>
 #include <thread>
+#include <format>
+#include <chrono>
 #include <boost/program_options.hpp>
 #include <boost/asio/thread_pool.hpp>
 #include <boost/asio/post.hpp>
 #include "DataOutput.hpp"
 #include "DataInput.hpp"
-#include "ParamStructs.hpp"
 #include "GDALRasterImage.hpp"
 #include "3pgModel.hpp"
 

--- a/apps/main.cpp
+++ b/apps/main.cpp
@@ -30,6 +30,13 @@ Use of this software assumes agreement to this condition of use
 #include "GDALRasterImage.hpp"
 #include "3pgModel.hpp"
 
+// OS-dependent path separator
+#ifdef _WIN32
+    const char PATH_SEPARATOR = '\\';
+#else
+    const char PATH_SEPARATOR = '/';
+#endif
+
 //----------------------------------------------------------------------------------------
 std::string VERSION = "3.0";
 std::string COPYMSG = 
@@ -242,9 +249,9 @@ bool getOutPath(std::string siteParamString, std::string& outpath)
         //get path string
         std::string path = values.front();
 
-        //add trailing backshlashes ifnecessary
-        if (path.back() != '\\') {
-            path += '\\';
+        //add trailing backshlashes if necessary
+        if (path.back() != PATH_SEPARATOR) {
+            path += PATH_SEPARATOR;
         }
         
         //ensure path exists

--- a/make_build.sh
+++ b/make_build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+rm -rf build && mkdir build
+cmake -B build

--- a/run_tests.bat
+++ b/run_tests.bat
@@ -1,6 +1,5 @@
-mkdir build 2>null
+mkdir build
 cmake -D CMAKE_BUILD_TYPE=Debug -B build
 cmake --build build
 cd build/tests
 ctest -C Debug
-del null

--- a/run_tests.bat
+++ b/run_tests.bat
@@ -1,5 +1,5 @@
 mkdir build
 cmake -D CMAKE_BUILD_TYPE=Debug -B build
-cmake --build build
+cmake --build build -j 4
 cd build/tests
 ctest -C Debug

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+mkdir build
+cmake -G "Unix Makefiles" -D CMAKE_BUILD_TYPE=Debug -B build
+cmake --build build
+cd build/tests
+ctest -C Debug --verbose

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,6 +2,6 @@
 
 mkdir build
 cmake -G "Unix Makefiles" -D CMAKE_BUILD_TYPE=Debug -B build
-cmake --build build
+cmake --build build -j 4
 cd build/tests
 ctest -C Debug

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -4,4 +4,4 @@ mkdir build
 cmake -G "Unix Makefiles" -D CMAKE_BUILD_TYPE=Debug -B build
 cmake --build build
 cd build/tests
-ctest -C Debug --verbose
+ctest -C Debug

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,19 +14,19 @@ FetchContent_MakeAvailable(googletest)
 
 enable_testing()
 
-#tester tests
-add_executable( hello_test hello_test.cpp )
-target_link_libraries( hello_test GTest::gtest_main )
-add_test( NAME hello_test COMMAND hello_test )
+# Tester tests
+add_executable(hello_test hello_test.cpp)
+target_link_libraries(hello_test PRIVATE GTest::gtest_main)
+add_test(NAME hello_test COMMAND hello_test)
 
-#DataInput tests
-add_executable( DataInputTests DataInputTests.cpp )
-target_link_libraries( DataInputTests GTest::gtest_main GDAL::GDAL "${PROJECT_SOURCE_DIR}/build/apps/Debug/3pg2Test.lib")
-add_test( NAME DataInputTests COMMAND DataInputTests WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests)
+# DataInput tests
+add_executable(DataInputTests DataInputTests.cpp)
+target_link_libraries(DataInputTests PRIVATE GTest::gtest_main GDAL::GDAL 3pg2Test)
+add_test(NAME DataInputTests COMMAND DataInputTests WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests)
 
-#DataOutput tests
-add_executable( DataOutputTests DataOutputTests.cpp )
-target_link_libraries( DataOutputTests GTest::gtest_main GDAL::GDAL "${PROJECT_SOURCE_DIR}/build/apps/Debug/3pg2Test.lib")
-add_test( NAME DataOutputTests COMMAND DataOutputTests WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests)
+# DataOutput tests
+add_executable(DataOutputTests DataOutputTests.cpp)
+target_link_libraries(DataOutputTests PRIVATE GTest::gtest_main GDAL::GDAL 3pg2Test)
+add_test(NAME DataOutputTests COMMAND DataOutputTests WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests)
 
 include(GoogleTest)

--- a/tests/DataInputTests.cpp
+++ b/tests/DataInputTests.cpp
@@ -1198,7 +1198,7 @@ TEST(DataInputTests, managementTable) {
 
 	std::filesystem::path imagePath = std::filesystem::current_path();
 	imagePath /= "test_files";
-	imagePath /= "dataInputTests";
+	imagePath /= "DataInputTests";
 	imagePath /= "irr1997.tif";
 	std::cout << imagePath.string() << std::endl;
 

--- a/tests/test_files/DataInputTests/formatTest.txt
+++ b/tests/test_files/DataInputTests/formatTest.txt
@@ -1,4 +1,4 @@
 "Frost",
 1870 1 2 3 4 5 6 7 8 9 10 11 12
 1871 13 14 15 16 17 18 19 20 21 22 23 24
-1872 test_files\DataInputTests\NFFD01.tif test_files\DataInputTests\NFFD02.tif test_files\DataInputTests\NFFD03.tif test_files\DataInputTests\NFFD04.tif test_files\DataInputTests\NFFD05.tif test_files\DataInputTests\NFFD06.tif test_files\DataInputTests\NFFD07.tif test_files\DataInputTests\NFFD08.tif test_files\DataInputTests\NFFD09.tif test_files\DataInputTests\NFFD10.tif test_files\DataInputTests\NFFD11.tif test_files\DataInputTests\NFFD12.tif
+1872 test_files/DataInputTests/NFFD01.tif test_files/DataInputTests/NFFD02.tif test_files/DataInputTests/NFFD03.tif test_files/DataInputTests/NFFD04.tif test_files/DataInputTests/NFFD05.tif test_files/DataInputTests/NFFD06.tif test_files/DataInputTests/NFFD07.tif test_files/DataInputTests/NFFD08.tif test_files/DataInputTests/NFFD09.tif test_files/DataInputTests/NFFD10.tif test_files/DataInputTests/NFFD11.tif test_files/DataInputTests/NFFD12.tif


### PR DESCRIPTION
This pull request adds support for Linux (tested on Ubuntu 22.04) to the existing 3-PG codebase.

Main changes are:

- GDAL and Boost are dynamically linked via cmake
- Tests are reformatted for cross-compatability with Windows and Linux

The current implementation has passed all available tests.